### PR TITLE
BUG: handle case-sensitive targets

### DIFF
--- a/src/intersphinx.ts
+++ b/src/intersphinx.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import zlib from 'zlib';
 import fetch from 'node-fetch';
 import { isUrl } from 'myst-cli-utils';
-import type { Domains } from './types.js';
+import { Domains } from './types.js';
 
 type Entry = { type: string; location: string; display?: string };
 type InventoryItem = { location: string; display?: string };
@@ -132,7 +132,7 @@ export class Inventory {
           // wrong type value. type should be in the form of "{domain}:{objtype}"
           return;
         }
-        if (type === 'py:module' && this.getEntry({ type, name })) {
+        if (type === Domains.pyModule && this.getEntry({ type, name })) {
           // due to a bug in 1.1 and below,
           // two inventory entries are created
           // for Python modules, and the first
@@ -153,8 +153,12 @@ export class Inventory {
     }
     if (resolvedLocation.endsWith('$')) {
       // Maybe move this to the parse function only?
-      resolvedLocation =
-        resolvedLocation.slice(0, -1) + entry.name.toLowerCase().replace(/\s+/g, '-');
+      let name = entry.name;
+      if (entry.type == Domains.stdLabel || entry.type == Domains.stdTerm) {
+        name = entry.name.toLocaleLowerCase().replace(/\s+/g, '-');
+      }
+
+      resolvedLocation = resolvedLocation.slice(0, -1) + name;
     }
     const resolvedDisplay =
       !entry.display || entry.display.trim() === '-' ? undefined : entry.display.trim();

--- a/src/inventory.spec.ts
+++ b/src/inventory.spec.ts
@@ -22,4 +22,16 @@ describe('Test Inventory', () => {
     expect(entry?.location?.includes('abc.html')).toBe(true);
     expect(entry?.type).toBe('std:doc');
   });
+  test('Python inventory - case sensitive names', async () => {
+    // Python 3.11 includes both `class Match()` and `def match()` as targets
+    const inv = new Inventory({ path: 'https://docs.python.org/3.11' });
+    await inv.load();
+    expect(inv._loaded).toBe(true);
+    const entryClass = inv.getEntry({ name: 're.Match' });
+    expect(entryClass?.location?.endsWith('re.Match')).toBe(true);
+    expect(entryClass?.type).toBe('py:class');
+    const entryFunc = inv.getEntry({ name: 're.match' });
+    expect(entryFunc?.location?.endsWith('re.match')).toBe(true);
+    expect(entryFunc?.type).toBe('py:function');
+  });
 });


### PR DESCRIPTION
Originally discovered in https://github.com/jupyter-book/mystmd/issues/1758

I'm basing the conditional normalization off of what appears to be a related problem in sphinx:
https://github.com/sphinx-doc/sphinx/blob/d29c2c1ff31f9e70f201264cd97e855aca975b78/sphinx/util/inventory.py#L128-L147

But I may be incorrect here.