### PR TITLE
Expand `$` anchor shorthand verbatim (case-preserved), per Sphinx semantics

### DIFF
--- a/.changeset/dollar-anchor-case.md
+++ b/.changeset/dollar-anchor-case.md
@@ -1,0 +1,5 @@
+---
+'intersphinx': patch
+---
+
+Expand the `$` uri anchor shorthand with the object name verbatim (case-preserved), matching Sphinx semantics. Previously the expansion was lowercased and whitespace-replaced, which broke links to any case-distinct targets (e.g. `re.Match` vs `re.match` in the CPython inventory, and capitalized glossary terms like `#term-Match`).

--- a/src/intersphinx.ts
+++ b/src/intersphinx.ts
@@ -152,9 +152,11 @@ export class Inventory {
       resolvedLocation = resolvedLocation.slice(1);
     }
     if (resolvedLocation.endsWith('$')) {
-      // Maybe move this to the parse function only?
-      resolvedLocation =
-        resolvedLocation.slice(0, -1) + entry.name.toLowerCase().replace(/\s+/g, '-');
+      // Sphinx semantics: `$` is replaced by the object name *verbatim*.
+      // Case must be preserved: e.g. `re.match` (function) and `re.Match`
+      // (class) are distinct objects with distinct anchors.
+      // https://github.com/sphinx-doc/sphinx/blob/v8.2.3/sphinx/util/inventory.py#L154
+      resolvedLocation = resolvedLocation.slice(0, -1) + entry.name;
     }
     const resolvedDisplay =
       !entry.display || entry.display.trim() === '-' ? undefined : entry.display.trim();

--- a/src/inventory.spec.ts
+++ b/src/inventory.spec.ts
@@ -22,4 +22,36 @@ describe('Test Inventory', () => {
     expect(entry?.location?.includes('abc.html')).toBe(true);
     expect(entry?.type).toBe('std:doc');
   });
+  test('`$` anchor shorthand expands to the name verbatim (Sphinx semantics)', () => {
+    const inv = new Inventory({ id: 'test', path: 'https://example.org' });
+    // Sphinx only writes `$` when the anchor ends with the name byte-for-byte,
+    // so the expansion must preserve case exactly:
+    // re.match (function) and re.Match (class) are distinct targets.
+    inv.setEntry({ type: 'py:function', name: 're.match', location: 'library/re.html#$' });
+    inv.setEntry({ type: 'py:class', name: 're.Match', location: 'library/re.html#$' });
+    // A capitalized glossary term: Sphinx writes `Match std:term -1 index.html#term-$ -`
+    // and its real HTML anchor is `id="term-Match"` — also case-preserved.
+    inv.setEntry({ type: 'std:term', name: 'Match', location: 'index.html#term-$' });
+    expect(inv.getEntry({ name: 're.match' })?.location).toBe(
+      'https://example.org/library/re.html#re.match',
+    );
+    expect(inv.getEntry({ name: 're.Match' })?.location).toBe(
+      'https://example.org/library/re.html#re.Match',
+    );
+    expect(inv.getEntry({ type: 'std:term', name: 'Match' })?.location).toBe(
+      'https://example.org/index.html#term-Match',
+    );
+  });
+  test('Python inventory - case sensitive names', async () => {
+    // Python 3.11 includes both `class Match` and `def match()` as targets
+    const inv = new Inventory({ path: 'https://docs.python.org/3.11' });
+    await inv.load();
+    expect(inv._loaded).toBe(true);
+    const entryClass = inv.getEntry({ name: 're.Match' });
+    expect(entryClass?.location?.endsWith('re.Match')).toBe(true);
+    expect(entryClass?.type).toBe('py:class');
+    const entryFunc = inv.getEntry({ name: 're.match' });
+    expect(entryFunc?.location?.endsWith('re.match')).toBe(true);
+    expect(entryFunc?.type).toBe('py:function');
+  });
 });


### PR DESCRIPTION
Fixes the bug reported in jupyter-book/mystmd#1758; completes and slightly simplifies #5 (thanks @ebolyen for the original diagnosis and fix; this PR keeps your CPython test).

## The bug

A Sphinx v2 inventory row may abbreviate its uri with `$`, meaning "substitute the object name here". Sphinx expands it with the name **verbatim** ([`sphinx/util/inventory.py`](https://github.com/sphinx-doc/sphinx/blob/v8.2.3/sphinx/util/inventory.py#L154): `location = location[:-1] + name`). `Inventory.setEntry` expands it with `entry.name.toLowerCase().replace(/\s+/g, '-')`, so every case-distinct pair in a real Sphinx inventory collapses:

```bash
$ npx intersphinx@1.0.2 list https://docs.python.org/3 --includes re.Match
py:class  (re.Match)
  https://docs.python.org/3/library/re.html#re.match     # ← WRONG (function's anchor)

$ node dist/intersphinx.cjs list https://docs.python.org/3 --includes re.Match   # this PR
py:class  (re.Match)
  https://docs.python.org/3/library/re.html#re.Match     # ← matches Sphinx
```

URL fragments are case-sensitive, so the lowercased links land nowhere (or on the wrong object: `re.match` vs `re.Match`).

## Why unconditional (the one difference from #5)

#5 keeps the lowercase + whitespace-replace behaviour for `std:label`/`std:term`. Two observations from Sphinx's source and output argue for expanding verbatim for **all** domains:

1. Sphinx's *writer* only compresses to `$` when the anchor ends with the name **byte-for-byte** (`inventory.py`: `if anchor.endswith(fullname)`). An anchor that differs from the name in case or whitespace is always written out explicitly, so a `$` row's only correct expansion is the verbatim name; the conditional branch has no legitimate input.
2. It actively breaks capitalized glossary terms. A minimal Sphinx project with a glossary entry `Match` publishes (verified with sphinx 9.1.0):

   ```text
   inventory row:      Match std:term -1 index.html#term-$ -
   real HTML anchor:   id="term-Match"
   verbatim expansion: index.html#term-Match   ✅
   lowercased:         index.html#term-match   ❌ broken anchor
   ```

   (Sphinx's case-insensitivity for `std:term`/`std:label` is a *lookup*-time fallback in `intersphinx/_resolve.py`; it never alters the target URL.)

3. Multi-word terms don't need the whitespace replacement either: `lower term std:term` is published with an explicit anchor `#term-lower-term` precisely because the anchor differs from the name, so no `$` is written.

## Changes

- `src/intersphinx.ts`: expand `$` with `entry.name` verbatim.
- `src/inventory.spec.ts`: offline round-trip test covering the `re.match`/`re.Match` pair and a capitalized `std:term`; plus the live docs.python.org 3.11 case-sensitivity test from #5.
- changeset (patch).

## Independent CI reproduction

https://github.com/coretl/mystmd-repro-repo runs this reproducer as a matrix: released `intersphinx@1.0.2` (asserting the bug) vs this branch (asserting Sphinx-verbatim behaviour): https://github.com/coretl/mystmd-repro-repo/actions

## Downstream

`mystmd` consumes this package for every `references:` inventory, so after a release it needs a dependency bump there to pick this up. Context for why we hit this: case-sensitive Python API cross-references, jupyter-book/mystmd#1259.

## AI Disclaimer

The code and this description were generated with AI and reviewed/tweaked by the author.


Fixes:
- https://github.com/jupyter-book/mystmd/issues/1758

Closes:
- #5